### PR TITLE
Fix issue with coercing a list of maps with a single attribute

### DIFF
--- a/lib/mix/tasks/compiler.ex
+++ b/lib/mix/tasks/compiler.ex
@@ -152,6 +152,10 @@ defmodule Mix.Tasks.Compile.Speck do
     {name, [:map], [], Enum.map(attributes_ast, &build_attribute/1)}
   end
 
+  defp build_attribute({:attribute, _, [[name], [do: attributes_ast]]}) do
+    {name, [:map], [], [build_attribute(attributes_ast)]}
+  end
+
   defp build_attribute({:attribute, _, [name, opts_ast, [do: {:__block__, _, attributes_ast}]]}) do
     {opts, _} = Code.eval_quoted(opts_ast)
     {name, :map, opts, Enum.map(attributes_ast, &build_attribute/1)}

--- a/protocol/test/map_list_single.ex
+++ b/protocol/test/map_list_single.ex
@@ -1,0 +1,7 @@
+struct TestSchema.MapListSingleAttribute
+
+name "map_list_single_attribute"
+
+attribute [:devices] do
+  attribute :type, :string
+end

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -137,7 +137,26 @@ defmodule Speck.Test do
       }}
   end
 
-  test "can coerce a list of maps" do
+  test "can coerce a list of maps with a single attribute" do
+    params = %{
+      "devices" => [
+        %{"type" => "imx6"},
+        %{"type" => "imx8"},
+        %{"type" => "am62"},
+      ]
+    }
+
+    assert Speck.validate(TestSchema.MapListSingleAttribute, params) ==
+      {:ok, %TestSchema.MapListSingleAttribute{
+        devices: [
+          %{type: "imx6"},
+          %{type: "imx8"},
+          %{type: "am62"},
+        ]
+      }}
+  end
+
+  test "can coerce a list of maps with multiple attributes" do
     params = %{
       "devices" => [
         %{"id" =>  1,  "type" => "valid"},


### PR DESCRIPTION
Resolves #5

This PR adds a maplist handler for when the opts aren't present.