### PR TITLE
Add parens to satisfy Elixir 1.17

### DIFF
--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -8,9 +8,9 @@ defmodule Speck do
   """
   @spec validate(schema :: module, params :: map) :: {:ok, struct}, {:error, map}
   def validate(schema, params) do
-    opts = [strict: schema.strict]
+    opts = [strict: schema.strict()]
 
-    case do_validate(:map, params, opts, schema.attributes) do
+    case do_validate(:map, params, opts, schema.attributes()) do
       {fields, errors} when errors == %{} ->
         struct = struct(schema, fields)
         {:ok, struct}


### PR DESCRIPTION
This eliminates the following warning otherwise generated by Elixir 1.17 and beyond:
```
using map.field notation (without parentheses) to invoke function TestSchema.Date.strict() is deprecated, you must add parentheses instead: remote.function()
```