### PR TITLE
Fix type spec on Speck.validate\2

### DIFF
--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -6,7 +6,7 @@ defmodule Speck do
   @doc """
   Validate and coerce the params according to a schema.
   """
-  @spec validate(schema :: module, params :: map) :: {:ok, struct}, {:error, map}
+  @spec validate(schema :: module, params :: map) :: {:ok, struct} | {:error, map}
   def validate(schema, params) do
     opts = [strict: schema.strict()]
 


### PR DESCRIPTION
Current format confuses dialyzer and it thinks the function will always return `{:ok, term}` causing simple `case` constructs to fail dialyzer.

```elixir
case Speck.validate(MySpec.V1, params) do
  {:ok, my_spec} -> {:ok, my_spec}
  error -> error
end

...

The pattern `variable_error` can never match, because previous clauses completely cover the type
{:ok, struct()}.
```