### PR TITLE
Updated Cache action since deprecated versions are no longer available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get dependencies
         run: mix deps.get --only dev
       - name: Restore PLTs
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: _build/dev/plt
           key: plt-${{ github.ref }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
-on:
-  - push
-  - pull_request
+on: push
 
 jobs:
   unit_tests:


### PR DESCRIPTION
According to the [README](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes), all deprecated Cache actions are no longer hosted and any CI pipeline using them will fail.