### PR TITLE
Optional Enumerables do not create empty instances when omitted

### DIFF
--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -25,15 +25,6 @@ defmodule Speck do
       !is_nil(opts[:default]) && is_nil(raw_value) ->
         {Map.put(fields, name, opts[:default]), errors}
 
-      type == :map ->
-        case do_validate(type, raw_value, opts, attributes) do
-          {value, map_errors} when map_errors == %{} ->
-            {Map.put(fields, name, value), errors}
-
-          {value, map_errors} ->
-            {Map.put(fields, name, value), Map.put(errors, name, map_errors)}
-        end
-
       opts[:optional] && is_nil(raw_value) && type == :boolean ->
         {Map.put(fields, name, false), errors}
 
@@ -42,6 +33,15 @@ defmodule Speck do
 
       opts[:optional] && is_nil(raw_value) ->
         {fields, errors}
+
+      type == :map ->
+        case do_validate(type, raw_value, opts, attributes) do
+          {value, map_errors} when map_errors == %{} ->
+            {Map.put(fields, name, value), errors}
+
+          {value, map_errors} ->
+            {Map.put(fields, name, value), Map.put(errors, name, map_errors)}
+        end
 
       is_list(type) ->
         raw_value
@@ -142,6 +142,12 @@ defmodule Speck do
           end)
 
         case coerced_maplist do
+          {[], []} ->
+            {fields, errors}
+
+          {[], error} ->
+            {fields, Map.put(errors, name, error)}
+
           {value, []} ->
             {Map.put(fields, name, value), errors}
 

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -79,14 +79,7 @@ defmodule Speck.Test do
         rs485_address: :not_present,
         serial_number: :not_present,
         dns_servers:   :not_present,
-        metadata: %{
-          location:        :not_present,
-          department:      :not_present,
-          commissioned_at: :not_present,
-          ports: %{
-            rs485: :not_present,
-          }
-        }
+        metadata: :not_present
       }}
   end
 


### PR DESCRIPTION
This PR address #15. If an `Enumerable` attribute (map or list-of-maps) is flagged as optional, and that attribute is not in the input, I'd expect the output from `Speck.validate/2` to be as minimal as possible. For a top-level attribute, that means a `nil` value. For anything below the top level, that would mean being entirely omitted from the output. To make this happen, I've made the handling of optional values a higher priority in `apply_filters`.

One behavioural change not directly related to the above is that a non-optional `Enumerable` that is omitted will not recursively report `:not_found` errors. Instead, the map/list-of-maps will itself be marked as `:not_found`, and the interior elements skipped entirely. The old behaviour is easy enough to re-implement by moving a condition in `apply_filters`.