### PR TITLE
Build attributes AST for non-:__block__ container attributes with opts

### DIFF
--- a/lib/mix/tasks/compiler.ex
+++ b/lib/mix/tasks/compiler.ex
@@ -160,6 +160,11 @@ defmodule Mix.Tasks.Compile.Speck do
     {name, [:map], [], Enum.map(attributes_ast, &build_attribute/1)}
   end
 
+  defp build_attribute({:attribute, _, [[name], opts_ast, [do: attributes_ast]]}) do
+    {opts, _} = Code.eval_quoted(opts_ast)
+    {name, [:map], opts, [build_attribute(attributes_ast)]}
+  end
+
   defp build_attribute({:attribute, _, [[name], [do: attributes_ast]]}) do
     {name, [:map], [], [build_attribute(attributes_ast)]}
   end
@@ -171,6 +176,11 @@ defmodule Mix.Tasks.Compile.Speck do
 
   defp build_attribute({:attribute, _, [name, [do: {:__block__, _, attributes_ast}]]}) do
     {name, :map, [], Enum.map(attributes_ast, &build_attribute/1)}
+  end
+
+  defp build_attribute({:attribute, _, [name, opts_ast, [do: attributes_ast]]}) do
+    {opts, _} = Code.eval_quoted(opts_ast)
+    {name, :map, opts, [build_attribute(attributes_ast)]}
   end
 
   defp build_attribute({:attribute, _, [name, [do: attributes_ast]]}) do


### PR DESCRIPTION
This PR addresses #18. It looks like there were some missing pattern matches for attributes that have `opts` and a `do` AST that is not a `:__block__`.