### PR TITLE
An optional list value should return nil if the incoming raw value is nil or not present

### DIFF
--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -142,6 +142,14 @@ defmodule Speck do
           end)
 
         case coerced_maplist do
+          {[], []} ->
+            value =
+              if opts[:optional] && is_nil(get_raw_value(value, name)),
+                do: nil,
+                else: []
+
+            {Map.put(fields, name, value), errors}
+
           {value, []} ->
             {Map.put(fields, name, value), errors}
 

--- a/protocol/test/list.ex
+++ b/protocol/test/list.ex
@@ -2,5 +2,4 @@ struct TestSchema.List
 
 name "list"
 
-attribute :device_ids, [:integer], min: 1,        max: 10
-attribute :statuses,   [:string],  optional: true
+attribute :device_ids, [:integer], min: 1, max: 10

--- a/protocol/test/list.ex
+++ b/protocol/test/list.ex
@@ -2,4 +2,5 @@ struct TestSchema.List
 
 name "list"
 
-attribute :device_ids, [:integer], min: 1, max: 10
+attribute :device_ids, [:integer], min: 1,        max: 10
+attribute :statuses,   [:string],  optional: true

--- a/protocol/test/optional_map_list.ex
+++ b/protocol/test/optional_map_list.ex
@@ -1,0 +1,10 @@
+struct TestSchema.OptionalMapList
+
+name "optional_map_list"
+
+attribute :status, :atom, values: [:pending, :failed]
+
+attribute [:transactions], optional: true do
+  attribute :id,     :integer
+  attribute :amount, :integer
+end

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -128,13 +128,13 @@ defmodule Speck.Test do
 
   test "return nil if optional list is not present" do
     params = %{
-      "device_ids" => [1, 2, 3],
+      "status" => "failed",
     }
 
-    assert Speck.validate(TestSchema.List, params) ==
-      {:ok, %TestSchema.List{
-        device_ids: [1, 2, 3],
-        statuses: nil
+    assert Speck.validate(TestSchema.OptionalMapList, params) ==
+      {:ok, %TestSchema.OptionalMapList{
+        status: :failed,
+        transactions: nil,
       }}
   end
 

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -126,6 +126,18 @@ defmodule Speck.Test do
       }}
   end
 
+  test "return nil if optional list is not present" do
+    params = %{
+      "device_ids" => [1, 2, 3],
+    }
+
+    assert Speck.validate(TestSchema.List, params) ==
+      {:ok, %TestSchema.List{
+        device_ids: [1, 2, 3],
+        statuses: nil
+      }}
+  end
+
   test "returns errors if a list can't be coerced" do
     params = %{
       "device_ids" => [-3, 0, 4, 19]


### PR DESCRIPTION
In a scenario where we have an optional list field with no default and incoming data does not contain the field such as:

```elixir
struct MyAwesomePayload

name "my_awesome_payload"

attribute :strings,   [:string],  optional: true
```

and lets say the incoming payload is:

```
%{}
```

Speck will coerce the incoming payload to `%{strings: []}` instead of `%{strings: nil}`.