### PR TITLE
Optional boolean that is not present returns nil

### DIFF
--- a/lib/speck.ex
+++ b/lib/speck.ex
@@ -57,13 +57,6 @@ defmodule Speck do
             }
         end
 
-      opts[:optional] && is_nil(raw_value) && type == :boolean ->
-        {
-          Map.put(fields, name, false),
-          errors,
-          make_meta(name, field_status, raw_value)
-        }
-
       is_nil(opts[:optional]) && is_nil(raw_value) ->
         {
           fields,
@@ -72,7 +65,11 @@ defmodule Speck do
         }
 
       opts[:optional] && is_nil(raw_value) ->
-        {fields, errors, make_meta(name, field_status, raw_value)}
+        {
+          Map.put(fields, name, nil),
+          errors,
+          make_meta(name, field_status, raw_value)
+        }
 
       is_list(type) ->
         raw_value

--- a/test/speck_test.exs
+++ b/test/speck_test.exs
@@ -7,6 +7,7 @@ defmodule Speck.Test do
       "type"           => "air_quality",
       "rs485_address"  => "5",
       "serial_number"  => "DEVICE1234567890",
+      # wifi_ssid      => not present
       # low_power_mode => not present
       "dns_servers"    => [
         "1.1.1.1",
@@ -34,7 +35,7 @@ defmodule Speck.Test do
         rs485_address:  5,
         serial_number:  "DEVICE1234567890",
         wifi_ssid:      nil,
-        low_power_mode: false,
+        low_power_mode: nil,
         dns_servers:    [
           "1.1.1.1",
           "1.0.0.1",
@@ -702,8 +703,8 @@ defmodule Speck.Test do
         attribute_5: 5
       },
       list_attribute_1: [
-        %{},
-        %{attribute_9: 9}
+        %{attribute_9: nil},
+        %{attribute_9: 9},
       ],
       list_attribute_2: []
     }
@@ -767,7 +768,7 @@ defmodule Speck.Test do
       partially_known_nested: %{
         attribute_5: 5
       },
-      list_attribute_1: [%{}],
+      list_attribute_1: [%{attribute_9: nil}],
       list_attribute_2: []
     }
 


### PR DESCRIPTION
In the case of the following spec, it would be expected that if `param1` is not present, the value would be `nil` (currently it is coerced to `false`). In this case, `true`/`false`/`nil` makes it easy to detect if the value was present, and is easy to "coerce" after validation with `if (data.param1)` or `!!param1`.

```ex
attribute :param1, :boolean, optional: true
```

If the intent is to use spec to coerce an optional property to only true/false, use `default`:

```ex
attribute :param1, :boolean, default: false
```